### PR TITLE
Added OutcomeTools.flatMap

### DIFF
--- a/src/tink/core/Outcome.hx
+++ b/src/tink/core/Outcome.hx
@@ -66,6 +66,15 @@ class OutcomeTools {
 					Failure(f);
 			}
 	
+	static public inline function flatMap<A, B, F>(outcome:Outcome<A, F>, transform: A->Outcome<B,F>) 
+		return 
+			switch (outcome) {
+				case Success(a): 
+					transform(a);
+				case Failure(f): 
+					Failure(f);
+			}
+	
 	static public inline function isSuccess<D, F>(outcome:Outcome<D, F>):Bool 
 		return 
 			switch outcome {


### PR DESCRIPTION
Any chance of adding this?  I thought this was already in there, but it was not, only when working with futures / surprises.

I have code that I would like to look like:

```
return
    findFile( '$repo/$path', Config.app.manual.extensions )
    .flatMap( readFile )
    .flatMap( toHtml );
```

where `findFile`, `readFile` and `toHtml` all return an Outcome with the same Failure type.  It's nicer than `map` where each transformation function adds another layer of `Outcome<>` to be dealt with in the next transformation function.
