### PR TITLE
Workaround for problem with Haxe type inference

### DIFF
--- a/src/tink/core/Error.hx
+++ b/src/tink/core/Error.hx
@@ -40,7 +40,7 @@ class Error {
 				throw this;
 			#end
 		
-	static public function withData(message, data, ?pos) {
+	static public function withData(message:String, data:Dynamic, ?pos:Pos) {
 		var ret = new Error(message, pos);
 		ret.data = data;
 		return ret;


### PR DESCRIPTION
An example of what did not work before: 

``` haxe
using tink.CoreApi;

class TinkErrorInference {
    static function main() {
        Error.withData( "Array", [1,2,3] );
        Error.withData( "Float", 2.0 );
        // TinkErrorInference.hx:6: characters 27-30 : Float should be Array<Int>
        // TinkErrorInference.hx:6: characters 27-30 : For function argument 'data'
    }
}
```
