### PR TITLE
Add Promise#mapError()

### DIFF
--- a/src/tink/core/Promise.hx
+++ b/src/tink/core/Promise.hx
@@ -27,6 +27,12 @@ abstract Promise<T>(Surprise<T, Error>) from Surprise<T, Error> to Surprise<T, E
       case Success(d): Future.sync(d);
       case Failure(e): f(e);
     });
+  
+  public function mapError(f:Error->Error):Promise<T>
+    return this.map(function(o) return switch o {
+      case Success(_): o;
+      case Failure(e): Failure(f(e));
+    });
         
   public inline function handle(cb:Callback<Outcome<T, Error>>):CallbackLink
     return this.handle(cb);


### PR DESCRIPTION
This is handy for transforming the error at the call site, before being propagated to some "central error handler".