### PR TITLE
Shortcut for converting error to promise

### DIFF
--- a/src/tink/CoreApi.hx
+++ b/src/tink/CoreApi.hx
@@ -29,6 +29,7 @@ typedef Noise = tink.core.Noise;
 
 typedef Error = tink.core.Error;
 typedef TypedError<T> = tink.core.Error.TypedError<T>;
+typedef ErrorTools = tink.core.Error.ErrorTools;
 
 typedef Callback<T> = tink.core.Callback<T>;
 typedef CallbackLink = tink.core.Callback.CallbackLink;

--- a/src/tink/core/Error.hx
+++ b/src/tink/core/Error.hx
@@ -136,3 +136,8 @@ abstract Stack(Array<StackItem>) from Array<StackItem> to Array<StackItem> {
   public inline function toString():String
     return CallStack.toString(this);
 }
+
+class ErrorTools {
+  public static inline function toPromise<T, E>(e:TypedError<E>):Promise<T>
+    return Promise.lift(e);
+}


### PR DESCRIPTION
I am just too lazy to write `Promise.lift(e)`.
If you agree, I may put similar things in OutcomeTools as well.