### PR TITLE
Add Promise.iterate()

### DIFF
--- a/src/tink/core/Promise.hx
+++ b/src/tink/core/Promise.hx
@@ -63,12 +63,6 @@ abstract Promise<T>(Surprise<T, Error>) from Surprise<T, Error> to Surprise<T, E
     return a.merge(b, function (a, b) return new Pair(a, b)); // TODO: a.merge(b, Pair.new); => File "src/typing/type.ml", line 555, characters 9-15: Assertion failed
     
     
-  static public inline function boolAnd(promises:Iterable<Promise<Bool>>, ?lazy):Promise<Bool>
-    return iterate(promises, function(v) return v ? None : Some(false), Success(true), lazy);
-    
-  static public inline function boolOr(promises:Iterable<Promise<Bool>>, ?lazy):Promise<Bool>
-    return iterate(promises, function(v) return v ? Some(true) : None, Success(false), lazy);
-    
   static public function iterate<A, R>(promises:Iterable<Promise<A>>, yield:Next<A, Option<R>>, finally:Promise<R>, ?lazy):Promise<R> {
     return Future.async(function(cb) {
       var iter = promises.iterator();

--- a/src/tink/core/Promise.hx
+++ b/src/tink/core/Promise.hx
@@ -63,13 +63,13 @@ abstract Promise<T>(Surprise<T, Error>) from Surprise<T, Error> to Surprise<T, E
     return a.merge(b, function (a, b) return new Pair(a, b)); // TODO: a.merge(b, Pair.new); => File "src/typing/type.ml", line 555, characters 9-15: Assertion failed
     
     
-  static public inline function boolAnd(promises:Array<Promise<Bool>>, ?lazy):Promise<Bool>
+  static public inline function boolAnd(promises:Iterable<Promise<Bool>>, ?lazy):Promise<Bool>
     return iterate(promises, function(v) return v ? None : Some(false), Success(true), lazy);
     
-  static public inline function boolOr(promises:Array<Promise<Bool>>, ?lazy):Promise<Bool>
+  static public inline function boolOr(promises:Iterable<Promise<Bool>>, ?lazy):Promise<Bool>
     return iterate(promises, function(v) return v ? Some(true) : None, Success(false), lazy);
     
-  static public function iterate<A, R>(promises:Array<Promise<A>>, yield:Next<A, Option<R>>, finally:Promise<R>, ?lazy):Promise<R> {
+  static public function iterate<A, R>(promises:Iterable<Promise<A>>, yield:Next<A, Option<R>>, finally:Promise<R>, ?lazy):Promise<R> {
     return Future.async(function(cb) {
       var iter = promises.iterator();
       function next() {

--- a/tests/Promises.hx
+++ b/tests/Promises.hx
@@ -79,6 +79,16 @@ class Promises extends Base {
       case null: Failure(new Error(422, '$s is not a valid integer'));
       case v: Success(v);
     }
+    
+  function testBoolAnd() {
+    Promise.boolAnd([true, true, true]).handle(function(o) assertTrue(o.match(Success(true))));
+    Promise.boolAnd([true, false, true]).handle(function(o) assertTrue(o.match(Success(false))));
+  }
+  
+  function testBoolOr() {
+    Promise.boolOr([false, false, false]).handle(function(o) assertTrue(o.match(Success(false))));
+    Promise.boolOr([false, false, true]).handle(function(o) assertTrue(o.match(Success(true))));
+  }
 
   function test() {
     var p:Promise<Int> = 5;

--- a/tests/Promises.hx
+++ b/tests/Promises.hx
@@ -80,14 +80,17 @@ class Promises extends Base {
       case v: Success(v);
     }
     
-  function testBoolAnd() {
-    Promise.boolAnd([true, true, true]).handle(function(o) assertTrue(o.match(Success(true))));
-    Promise.boolAnd([true, false, true]).handle(function(o) assertTrue(o.match(Success(false))));
-  }
-  
-  function testBoolOr() {
-    Promise.boolOr([false, false, false]).handle(function(o) assertTrue(o.match(Success(false))));
-    Promise.boolOr([false, false, true]).handle(function(o) assertTrue(o.match(Success(true))));
+  function testIterate() {
+    inline function boolAnd(promises:Iterable<Promise<Bool>>, ?lazy):Promise<Bool>
+      return Promise.iterate(promises, function(v) return v ? None : Some(false), true, lazy);
+      
+    inline function boolOr(promises:Iterable<Promise<Bool>>, ?lazy):Promise<Bool>
+      return Promise.iterate(promises, function(v) return v ? Some(true) : None, false, lazy);
+    
+    boolAnd([true, true, true]).handle(function(o) assertTrue(o.match(Success(true))));
+    boolAnd([true, false, true]).handle(function(o) assertTrue(o.match(Success(false))));
+    boolOr([false, false, false]).handle(function(o) assertTrue(o.match(Success(false))));
+    boolOr([false, false, true]).handle(function(o) assertTrue(o.match(Success(true))));
   }
 
   function test() {


### PR DESCRIPTION
`boolAnd` & `boolOr` are quite opinionated, let me know if they are not needed.

And I'm not sure if `yield` and `finally` should be async or not. It would be more generic if they are, but that will add some overhead for sync cases.