### PR TITLE
Add Promise.cache

### DIFF
--- a/src/tink/core/Promise.hx
+++ b/src/tink/core/Promise.hx
@@ -139,6 +139,18 @@ abstract Promise<T>(Surprise<T, Error>) from Surprise<T, Error> to Surprise<T, E
 
     return loop(0);
   }
+  
+  static public function cache<T>(gen:Void->Promise<T>, expire:Void->Future<Noise>):Void->Promise<T> {
+    var p = null;
+    return function() {
+      if(p == null) {
+        p = gen();
+        expire().handle(function(_) p = null);
+      }
+      #if debug if(p == null) throw 'Having a sync expire function means that you don\'t need to call Promise.cache at all'; #end
+      return p;
+    }
+  }
 
   @:noUsing 
   static public inline function lift<T>(p:Promise<T>)

--- a/tests/Promises.hx
+++ b/tests/Promises.hx
@@ -98,4 +98,21 @@ class Promises extends Base {
     }
   }
   
+  function testCache() {
+    var v = 0;
+    function gen() return Promise.lift(v++);
+    var expire = Future.trigger();
+    var cache = Promise.cache(gen, function() return expire);
+    cache().handle(function(v) assertTrue(v.match(Success(0))));
+    cache().handle(function(v) assertTrue(v.match(Success(0))));
+    expire.trigger(Noise);
+    expire = Future.trigger();
+    cache().handle(function(v) assertTrue(v.match(Success(1))));
+    cache().handle(function(v) assertTrue(v.match(Success(1))));
+    expire.trigger(Noise);
+    expire = Future.trigger();
+    cache().handle(function(v) assertTrue(v.match(Success(2))));
+    cache().handle(function(v) assertTrue(v.match(Success(2))));
+  }
+  
 }


### PR DESCRIPTION
`Promise.cache` returns a function which when called:

- create a promise if it is the first call; OR
- reuse the previous promise if not yet expired; OR
- create a new promise if the previous one is expired

Sample use:

```haxe
var example = Promise.cache(fetchExampleDotCom, triggerNoiseAfterDelayMs(1000));
example(); // will create a new promise that fetches example.com
example(); // will return the same promise (i.e. won't fetch again)

// after 1000ms
example(); // will fetch example.com again
```
