### PR TITLE
Error code addition

### DIFF
--- a/src/tink/core/Error.hx
+++ b/src/tink/core/Error.hx
@@ -39,6 +39,14 @@ typedef Error = TypedError<Dynamic>;
   var InsufficientStorage = 507;
   var BandwidthLimitExceeded = 509;
 
+  var PrivateConstructor = 10010;
+  var VirtualMethod = 10011;
+  var NullPointer = 10012;
+  var IllegalArgument = 10013;
+  var UnsupportedOperation = 10014;
+  var IllegalState = 10015;
+  var OperationCancelled = 10016;
+  var AssertionFailure = 10017;
 }
 
 class TypedError<T> {


### PR DESCRIPTION
Error code additions. Not convinced by this PR, I mean, wouldn't be better to refactor TypedError constructor to accept an Abstract instead of a closed enum, and make multiple enums possible relying on this abstract? It would allow anyone to extend the list from outside and keep pattern matching possible.