### PR TITLE
Fix lazy const map being eager

### DIFF
--- a/haxe_libraries/hxnodejs.hxml
+++ b/haxe_libraries/hxnodejs.hxml
@@ -1,6 +1,6 @@
-# @install: lix --silent download 'haxelib:hxnodejs#4.0.9' into hxnodejs/4.0.9/haxelib
+# @install: lix --silent download "haxelib:hxnodejs#4.0.9" into hxnodejs/4.0.9/haxelib
 -D hxnodejs=4.0.9
--cp ${HAXESHIM_LIBCACHE}/hxnodejs/4.0.9/haxelib/src
+-cp ${HAXE_LIBCACHE}/hxnodejs/4.0.9/haxelib/src
 -D nodejs
 --macro allowPackage('sys')
 --macro _hxnodejs.VersionWarning.include()

--- a/haxe_libraries/travix.hxml
+++ b/haxe_libraries/travix.hxml
@@ -1,3 +1,4 @@
-# @install: lix --silent download 'haxelib:travix#0.9.0' into travix/0.9.0/haxelib
+# @run: haxelib run-dir travix ${HAXE_LIBCACHE}/travix/0.9.0/haxelib
+# @install: lix --silent download "haxelib:travix#0.9.0" into travix/0.9.0/haxelib
 -D travix=0.9.0
--cp ${HAXESHIM_LIBCACHE}/travix/0.9.0/haxelib/src
+-cp ${HAXE_LIBCACHE}/travix/0.9.0/haxelib/src

--- a/src/tink/core/Lazy.hx
+++ b/src/tink/core/Lazy.hx
@@ -1,22 +1,22 @@
 package tink.core;
 
 abstract Lazy<T>(LazyObject<T>) from LazyObject<T> {
-  
+
   @:to public inline function get():T
     return this.get();
-      
-  @:from static public inline function ofFunc<T>(f:Void->T):Lazy<T> 
+
+  @:from static public inline function ofFunc<T>(f:Void->T):Lazy<T>
     return new LazyFunc(f);
 
-  public inline function map<A>(f:T->A):Lazy<A> 
+  public inline function map<A>(f:T->A):Lazy<A>
     return this.map(f);
-    
-  public inline function flatMap<A>(f:T->Lazy<A>):Lazy<A> 
+
+  public inline function flatMap<A>(f:T->Lazy<A>):Lazy<A>
     return this.flatMap(f);
-  
+
   @:from @:noUsing static inline function ofConst<T>(c:T):Lazy<T>
     return new LazyConst(c);
-}  
+}
 
 private interface LazyObject<T> {
   function get():T;
@@ -25,7 +25,7 @@ private interface LazyObject<T> {
 }
 
 private class LazyConst<T> implements LazyObject<T> {
-  
+
   var value:T;
 
   public inline function new(value)
@@ -35,19 +35,19 @@ private class LazyConst<T> implements LazyObject<T> {
     return value;
 
   public inline function map<R>(f:T->R):Lazy<R>
-    return new LazyConst(f(value));
+    return new LazyFunc(function () return f(value));
 
   public inline function flatMap<R>(f:T->Lazy<R>):Lazy<R>
-    return f(value);
+    return new LazyFunc(function () return f(value).get());
 }
 
 private class LazyFunc<T> implements LazyObject<T> {
   var f:Void->T;
   var result:T;
   #if debug var busy = false; #end
-  
+
   public function new(f) this.f = f;
-  
+
   public function get() {
     #if debug if (busy) throw new Error('circular lazyness');#end
     if (f != null) {

--- a/tests/Lazies.hx
+++ b/tests/Lazies.hx
@@ -3,33 +3,34 @@ package;
 using tink.CoreApi;
 
 class Lazies extends Base {
-	function testConst() {
-		var counter = 0;
+  function testConst() {
+    var counter = 0;
 
-		function double(x):Int {
-			++counter;
-			return x * 2;
-		}
+    function double(x):Int {
+      ++counter;
+      return x * 2;
+    }
 
-		function lazyDouble(x):Lazy<Int> {
-			++counter;
-			return x * 2;
-		}
+    function lazyDouble(x):Lazy<Int> {
+      ++counter;
+      return x * 2;
+    }
 
-		var i:Lazy<Int> = 7;
+    var i:Lazy<Int> = 7;
 
-		var j = i.map(double);
-		assertEquals(0, counter);
-		assertEquals(j.get(), 14);
-		j.get();
-		assertEquals(1, counter);
+    var j = i.map(double);
+    assertEquals(0, counter);
+    assertEquals(j.get(), 14);
+    j.get();
+    assertEquals(1, counter);
 
-		counter = 0;
+    counter = 0;
 
-		var k = i.flatMap(lazyDouble);
-		assertEquals(0, counter);
-		assertEquals(k.get(), 14);
-		k.get();
-		assertEquals(1, counter);
-	}
+    var k = i.flatMap(lazyDouble);
+    assertEquals(0, counter);
+    assertEquals(k.get(), 14);
+    k.get();
+    assertEquals(1, counter);
+  }
 }
+

--- a/tests/Lazies.hx
+++ b/tests/Lazies.hx
@@ -3,7 +3,7 @@ package;
 using tink.CoreApi;
 
 class Lazies extends Base {
-  function testConst() {
+  function testLaziness() {
     var counter = 0;
 
     function double(x):Int {
@@ -16,21 +16,23 @@ class Lazies extends Base {
       return x * 2;
     }
 
-    var i:Lazy<Int> = 7;
+    function test(i:Lazy<Int>, expected:Int) {
+      counter = 0;
+      var j = i.map(double);
+      assertEquals(0, counter);
+      assertEquals(j.get(), expected);
+      j.get();
+      assertEquals(1, counter);
 
-    var j = i.map(double);
-    assertEquals(0, counter);
-    assertEquals(j.get(), 14);
-    j.get();
-    assertEquals(1, counter);
+      counter = 0;
+      var k = i.flatMap(lazyDouble);
+      assertEquals(0, counter);
+      assertEquals(k.get(), expected);
+      k.get();
+      assertEquals(1, counter);
+    }
 
-    counter = 0;
-
-    var k = i.flatMap(lazyDouble);
-    assertEquals(0, counter);
-    assertEquals(k.get(), 14);
-    k.get();
-    assertEquals(1, counter);
+    test(7, 14);
+    test(function () return 11, 22);
   }
 }
-

--- a/tests/Lazies.hx
+++ b/tests/Lazies.hx
@@ -1,0 +1,35 @@
+package;
+
+using tink.CoreApi;
+
+class Lazies extends Base {
+	function testConst() {
+		var counter = 0;
+
+		function double(x):Int {
+			++counter;
+			return x * 2;
+		}
+
+		function lazyDouble(x):Lazy<Int> {
+			++counter;
+			return x * 2;
+		}
+
+		var i:Lazy<Int> = 7;
+
+		var j = i.map(double);
+		assertEquals(0, counter);
+		assertEquals(j.get(), 14);
+		j.get();
+		assertEquals(1, counter);
+
+		counter = 0;
+
+		var k = i.flatMap(lazyDouble);
+		assertEquals(0, counter);
+		assertEquals(k.get(), 14);
+		k.get();
+		assertEquals(1, counter);
+	}
+}

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -21,6 +21,7 @@ class RunTests {
     new Annexes(),
     new Options(),
     new Errors(),
+    new Lazies(),
   ];
   static function main() {  
     #if js//works for nodejs and browsers alike


### PR DESCRIPTION
Unless I'm mistaken, there is a problem with `map` and `flatMap` in `LazyConst` - they are actually eagerly evaluated.
This PR also adds a minimal test for `Lazy`

PS Also changed single quotes to double quotes in haxe_libraries hxml files - those are not liked by newest lix on Windows