### PR TITLE
Disable Promise.cache() in java

### DIFF
--- a/src/tink/core/Promise.hx
+++ b/src/tink/core/Promise.hx
@@ -162,7 +162,8 @@ abstract Promise<T>(Surprise<T, Error>) from Surprise<T, Error> to Surprise<T, E
 
     return loop(0);
   }
-  
+
+  #if !java
   static public function cache<T>(gen:Void->Promise<Pair<T, Future<Noise>>>):Void->Promise<T> {
     var p = null;
     return function() {
@@ -184,6 +185,7 @@ abstract Promise<T>(Surprise<T, Error>) from Surprise<T, Error> to Surprise<T, E
       });
     }
   }
+  #end
 
   @:noUsing 
   static public inline function lift<T>(p:Promise<T>)

--- a/tests/Promises.hx
+++ b/tests/Promises.hx
@@ -111,6 +111,7 @@ class Promises extends Base {
     }
   }
   
+  #if !java
   function testCache() {
     var v = 0;
     var expire = Future.trigger();
@@ -138,5 +139,6 @@ class Promises extends Base {
     cache().handle(function(o) assertTrue(getError(o) == 4));
     cache().handle(function(o) assertTrue(getError(o) == 5));
   }
+  #end
   
 }


### PR DESCRIPTION
#80 broke java target even when we do not explicitly use `Promise.cache()`.

Seems like that didn't disturb you too much when you found out java didn't like it :D But it breaks things, like [buddy](https://github.com/ciscoheat/buddy).
 
Everything works fine when surrounding `cache` by `#if !java`. Maybe there is a fix for making it work with java, but I have no idea atm.

Sorry about the whitespace diff, there was mixed line endings =/ You can see the "real" diff [here](https://github.com/haxetink/tink_core/pull/85/files?w=1)