### PR TITLE
Callback.SimpleLink: reset to null after dissolve

### DIFF
--- a/src/tink/core/Callback.hx
+++ b/src/tink/core/Callback.hx
@@ -17,9 +17,10 @@ abstract Callback<T>(T->Void) from (T->Void) {
       depth--;
     }
     else Callback.defer(invoke.bind(data));
-    
-  @:to static function ignore<T>(cb:Callback<Noise>):Callback<T>
-    return function () cb.invoke(Noise);
+  
+  // This seems useful, but most likely is not. Please create an issue if you find it useful, and don't want this cast removed.
+  @:to @:deprecated static function ignore<T>(cb:Callback<Noise>):Callback<T>
+    return function (_) cb.invoke(Noise);
     
   @:from static function fromNiladic<A>(f:Void->Void):Callback<A> //inlining this seems to cause recursive implicit casts
     return new Callback(function (r) f());

--- a/src/tink/core/Callback.hx
+++ b/src/tink/core/Callback.hx
@@ -23,7 +23,7 @@ abstract Callback<T>(T->Void) from (T->Void) {
     return function (_) cb.invoke(Noise);
     
   @:from static function fromNiladic<A>(f:Void->Void):Callback<A> //inlining this seems to cause recursive implicit casts
-    return new Callback(function (r) f());
+    return function (_) f();
   
   @:from static function fromMany<A>(callbacks:Array<Callback<A>>):Callback<A> 
     return
@@ -31,7 +31,7 @@ abstract Callback<T>(T->Void) from (T->Void) {
         for (callback in callbacks)
           callback.invoke(v);
           
-  @:noUsing static public function defer(f:Void->Void) {    
+  @:noUsing static public function defer(f:Void->Void) {
     #if macro
       f();
     #elseif tink_runloop
@@ -86,7 +86,10 @@ private class SimpleLink implements LinkObject {
     this.f = f;
 
   public inline function dissolve()
-    if (f != null) f();
+    if (f != null) {
+      f();
+      f = null;
+    }
 }
 
 private class LinkPair implements LinkObject {
@@ -104,6 +107,8 @@ private class LinkPair implements LinkObject {
       dissolved = true;
       a.dissolve();
       b.dissolve();
+      a = null;
+      b = null;
     }
 }
 

--- a/tests/Callbacks.hx
+++ b/tests/Callbacks.hx
@@ -12,7 +12,7 @@ class Callbacks extends Base {
     cbs.push(cbs.copy());
     
     for (c in cbs) 
-      c.invoke(4);
+      c.invoke(17);
       
     assertEquals(4, calls);
   }
@@ -33,6 +33,46 @@ class Callbacks extends Base {
     assertEquals(0, counter);
   }
   #end
+  
+  function testIgnore() {
+    var calls = 0;
+    var cbNoise:Callback<Noise> = function () calls++;
+    var cb:Callback<Int> = cbNoise;
+    cb.invoke(17);
+    assertEquals(1, calls);
+  }
+  
+  function testSimpleLink() {
+    var calls = 0;
+    var link:CallbackLink = function () calls++;
+    link.dissolve();
+    link.dissolve();
+    assertEquals(calls, 1);
+  }
+  
+  function testLinkPair() {
+    var calls = 0,
+      calls1 = 0,
+      calls2 = 0;
+    
+    var link1:CallbackLink = function () { calls++; calls1++; }
+    var link2:CallbackLink = function () { calls++; calls2++; }
+    var link = link1 & link2;
+    
+    link.dissolve();
+    assertEquals(2, calls);
+    assertEquals(1, calls1);
+    assertEquals(1, calls2);
+    
+    link.dissolve();
+    assertEquals(2, calls);
+    
+    link1.dissolve();
+    assertEquals(1, calls1);
+    
+    link2.dissolve();
+    assertEquals(1, calls2);
+  }
   
   function testList() {
     var cb = new CallbackList();


### PR DESCRIPTION
This PR actually does more than one thing to `Callback`, which is arguably not the best practice :)
- SimpleLink: Set `f` to null at the end of `dissolve`, to behave like `LinkPair` or `CallbackList`
- Callback: Deprecate `ignore` which is most likely not useful
- Add a few more tests