### PR TITLE
Add PromiseTrigger and Promise.make helper

### DIFF
--- a/src/tink/CoreApi.hx
+++ b/src/tink/CoreApi.hx
@@ -10,6 +10,7 @@ typedef Future<T> = tink.core.Future<T>;
 typedef Surprise<D, F> = tink.core.Future.Surprise<D, F>;
 #if js typedef JsPromiseTools = tink.core.Future.JsPromiseTools; #end
 typedef FutureTrigger<T> = tink.core.Future.FutureTrigger<T>;
+typedef PromiseTrigger<T> = tink.core.Promise.PromiseTrigger<T>;
 
 typedef Outcome<D, F> = tink.core.Outcome<D, F>;
 typedef OutcomeTools = tink.core.Outcome.OutcomeTools;

--- a/src/tink/core/Promise.hx
+++ b/src/tink/core/Promise.hx
@@ -205,6 +205,21 @@ abstract Promise<T>(Surprise<T, Error>) from Surprise<T, Error> to Surprise<T, E
   @:noUsing 
   static public inline function lift<T>(p:Promise<T>)
     return p;
+    
+  
+  @:noUsing
+  static public function make<A>(f:(A->Void)->(Error->Void)->Void, lazy = false):Promise<A> {
+    return Future.async(function(cb) {
+      f(function(v) cb(Success(v)), function(e) cb(Failure(e)));
+    }, lazy);
+  }
+    
+  /**
+   *  Creates a new `PromiseTrigger`
+   */
+  @:noUsing
+  static public inline function trigger<A>():PromiseTrigger<A> 
+    return new PromiseTrigger(); 
 }
 
 @:callable
@@ -242,4 +257,12 @@ abstract Combiner<In1, In2, Out>(In1->In2->Promise<Out>) from In1->In2->Promise<
   @:from static function ofSafeSync<In1, In2, Out>(f:In1->In2->Out):Combiner<In1, In2, Out> 
     return function (x1, x2) return f(x1, x2);
 	
+}
+
+@:forward
+abstract PromiseTrigger<T>(FutureTrigger<Outcome<T, Error>>) from FutureTrigger<Outcome<T, Error>> to FutureTrigger<Outcome<T, Error>> {
+  public inline function new() this = Future.trigger();
+  public inline function resolve(v:T) return this.trigger(Success(v));
+  public inline function reject(e:Error) return this.trigger(Failure(e));
+  @:to public inline function asPromise():Promise<T> return this;
 }

--- a/src/tink/core/Promise.hx
+++ b/src/tink/core/Promise.hx
@@ -264,5 +264,5 @@ abstract PromiseTrigger<T>(FutureTrigger<Outcome<T, Error>>) from FutureTrigger<
   public inline function new() this = Future.trigger();
   public inline function resolve(v:T) return this.trigger(Success(v));
   public inline function reject(e:Error) return this.trigger(Failure(e));
-  @:to public inline function asPromise():Promise<T> return this;
+  @:to public inline function asPromise():Promise<T> return this.asFuture();
 }

--- a/src/tink/core/Promise.hx
+++ b/src/tink/core/Promise.hx
@@ -8,6 +8,12 @@ abstract Promise<T>(Surprise<T, Error>) from Surprise<T, Error> to Surprise<T, E
   public static var NOISE:Promise<Noise> = Future.sync(Success(Noise));
   public static var NEVER:Promise<Dynamic> = Future.NEVER;
   
+  public inline function new(f:(T->Void)->(Error->Void)->Void, lazy = false) {
+    this = Future.async(function(cb) {
+      f(function(v) cb(Success(v)), function(e) cb(Failure(e)));
+    }, lazy);
+  }
+  
   public inline function eager():Promise<T>
     return this.eager();
 
@@ -205,14 +211,6 @@ abstract Promise<T>(Surprise<T, Error>) from Surprise<T, Error> to Surprise<T, E
   @:noUsing 
   static public inline function lift<T>(p:Promise<T>)
     return p;
-    
-  
-  @:noUsing
-  static public function make<A>(f:(A->Void)->(Error->Void)->Void, lazy = false):Promise<A> {
-    return Future.async(function(cb) {
-      f(function(v) cb(Success(v)), function(e) cb(Failure(e)));
-    }, lazy);
-  }
     
   /**
    *  Creates a new `PromiseTrigger`


### PR DESCRIPTION
`PromiseTrigger<T>` is a shorthand for `FutureTrigger<Outcome<T, Error>>`

`Promise.make` mainly targets JS users and help them to migrate to tink.
So that they can create promises in a more JS-ish way:

```haxe
Promise.make((resolve, reject) -> {...});
```