### PR TITLE
Use Std.downcast() instead of Std.instance()

### DIFF
--- a/src/tink/core/Error.hx
+++ b/src/tink/core/Error.hx
@@ -112,6 +112,8 @@ class TypedError<T> {
       #if js
         if (v != null && (cast v:Error).isTinkError) cast v;
         else null;
+      #elseif haxe4
+        Std.downcast(v, Error);
       #else
         Std.instance(v, Error);
       #end


### PR DESCRIPTION
From Haxe 4.0.0-rc.3 Std.instance() has been renamed.