### PR TITLE
Fix __js__ deprecation warning with Haxe 4.1.0 nightlies

### DIFF
--- a/src/tink/core/Error.hx
+++ b/src/tink/core/Error.hx
@@ -153,7 +153,11 @@ class TypedError<T> {
 
   static public function tryFinally<T>(f:Void->T, cleanup:Void->Void):T {
     #if js
+      #if haxe4
+      js.Syntax.code('try { return f(); } finally { cleanup(); }');
+      #else
       untyped __js__('try { return f(); } finally { cleanup(); }');
+      #end
       return null;
     #else
     try {


### PR DESCRIPTION
```
Warning : __js__ is deprecated, use js.Syntax.code instead
```

Not sure if you still care about backwards compatibility with Haxe versions < 4? If not the conditional isn't needed.