### PR TITLE
Don't use tink.CoreApi inside tink.core itself (related to #119)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-bin
+/bin
+/node_modules

--- a/src/tink/core/Future.hx
+++ b/src/tink/core/Future.hx
@@ -1,9 +1,10 @@
 package tink.core;
 
-import tink.core.Signal;
 import tink.core.Callback;
-
-using tink.CoreApi;
+import tink.core.Noise;
+import tink.core.Outcome;
+import tink.core.Promise;
+import tink.core.Signal.Gather;
 
 #if js
 import #if haxe4 js.lib.Error #else js.Error #end as JsError;

--- a/src/tink/core/Progress.hx
+++ b/src/tink/core/Progress.hx
@@ -5,7 +5,7 @@ import tink.core.Future;
 import tink.core.Signal;
 
 using tink.core.Progress.TotalTools;
-using tink.CoreApi;
+using tink.core.Option;
 
 @:forward(result)
 abstract Progress<T>(ProgressObject<T>) from ProgressObject<T> {

--- a/src/tink/core/Promise.hx
+++ b/src/tink/core/Promise.hx
@@ -1,11 +1,15 @@
 package tink.core;
 
+import tink.core.Callback;
+import tink.core.Error;
+import tink.core.Future;
+import tink.core.Noise;
+import tink.core.Outcome;
 import tink.core.Signal.Gather;
-using tink.CoreApi;
 
 #if js
-import #if haxe4 js.lib.Promise #else js.Promise #end as JsPromise;
 import #if haxe4 js.lib.Error #else js.Error #end as JsError;
+import #if haxe4 js.lib.Promise #else js.Promise #end as JsPromise;
 #end
 
 @:forward(status)


### PR DESCRIPTION
The motivation is to not include the whole library when you use only a part of it, because not everyone is type-safe enough to compile with dce=full :)