### PR TITLE
Non-lazy sync futures without extra allocation

### DIFF
--- a/src/tink/core/Lazy.hx
+++ b/src/tink/core/Lazy.hx
@@ -31,12 +31,12 @@ abstract Lazy<T>(LazyObject<T>) from LazyObject<T> {
     return new LazyConst(c);
 }
 
-private interface LazyObject<T> extends Computable {
+interface LazyObject<T> extends Computable {
   function isComputed():Bool;
   function get():T;
 }
 
-private interface Computable {
+interface Computable {
   function isComputed():Bool;
   function compute():Void;
   function underlying():Null<Computable>;


### PR DESCRIPTION
I couldn't sleep and I remembered one thing that was bothering me about tink futures: 
Currently `Future.sync(42)` will generate `new SyncFuture(new LazyConst(42))`, which is not a huge issue, because sync futures are not that frequent in general, but still a bit unfortunate.

So I added some abstract magic to overload the `sync` constructor to instantiate a yet another underlying Future implementation when the value is not `Lazy<T>`: `SyncFutureConst`, which is both `FutureObject` and `LazyObject` (the latter is needed for `FutureStatus.Ready`).

The current state is a bit dirty wrt naming and the fact that I had to un-private Lazy interfaces, but I'm curious about your opinion on the general approach here and whether you think it's worth it at all (I guess that depends on the target allocator/gc).