### PR TITLE
use function field instead of dynamic function

### DIFF
--- a/src/tink/core/Callback.hx
+++ b/src/tink/core/Callback.hx
@@ -178,7 +178,7 @@ class CallbackList<T> extends SimpleDisposable {
     this.cells = [];
   }
 
-  dynamic public function ondrain() {}
+  public var ondrain:()->Void = function() {}
 
   inline function release()
     if (--used <= length >> 1)


### PR DESCRIPTION
the difference is that dynamic function is `$bind`-ed in `drain`,
while a functional field isn't and since we don't need binding
we can save a couple ticks