### PR TITLE
Cleanup or() functions

### DIFF
--- a/src/tink/core/Option.hx
+++ b/src/tink/core/Option.hx
@@ -4,10 +4,14 @@ typedef Option<T> = haxe.ds.Option<T>;
 
 class OptionTools {
   
+  @:deprecated('Use .sure() instead')
+  static public inline function force<T>(o:Option<T>, ?pos:tink.core.Error.Pos)
+    return sure(o, pos);
+  
   /**
    *  Extracts the value if the option is `Some`, throws an `Error` otherwise
    */
-  static public inline function force<T>(o:Option<T>, ?pos:tink.core.Error.Pos)
+  static public inline function sure<T>(o:Option<T>, ?pos:tink.core.Error.Pos)
     return switch o {
       case Some(v): 
         v;

--- a/src/tink/core/Option.hx
+++ b/src/tink/core/Option.hx
@@ -14,7 +14,20 @@ class OptionTools {
       default: 
         throw new Error(NotFound, 'Some value expected but none found', pos);
     }
+    
+  /**
+   *  Creates an `Outcome` from an `Option`, with made-up `Failure` information
+   */
+  static public function toOutcome<D>(o:Option<D>, ?pos:haxe.PosInfos):Outcome<D, Error>
+    return
+      switch o {
+        case Some(value):
+          Success(value);
+        case None:
+          Failure(new Error(NotFound, 'Some value expected but none found in ' + pos.fileName + '@line ' + pos.lineNumber));
+      }
   
+      
   /**
    *  Extracts the value if the option is `Some`, uses the fallback value otherwise
    */
@@ -22,6 +35,15 @@ class OptionTools {
     return switch o {
       case Some(v): v;
       default: l.get();
+    }
+  
+  /**
+   *  Extracts the value if the option is `Some`, uses the fallback value otherwise
+   */
+  static public inline function orTry<T>(o:Option<T>, fallback:Lazy<Option<T>>):Option<T>
+    return switch o {
+      case Some(v): o;
+      default: fallback.get();
     }
 
   /**

--- a/src/tink/core/Outcome.hx
+++ b/src/tink/core/Outcome.hx
@@ -37,18 +37,6 @@ class OutcomeTools {
       }
 
   /**
-   *  Creates an `Outcome` from an `Option`, with made-up `Failure` information
-   */
-  static public function toOutcome<D>(option:Option<D>, ?pos:haxe.PosInfos):Outcome<D, Error>//TODO: this should go into OptionTools in the next major release
-    return
-      switch (option) {
-        case Some(value):
-          Success(value);
-        case None:
-          Failure(new Error(NotFound, 'Some value expected but none found in ' + pos.fileName + '@line ' + pos.lineNumber));
-      }
-
-  /**
    *  Extracts the value if the option is `Success`, otherwise `null`
    */
   static public function orNull<D, F>(outcome: Outcome<D, F>):Null<D>
@@ -58,10 +46,14 @@ class OutcomeTools {
         case Failure(_): null;
       }
 
+  @:deprecated('Use .or() instead')
+  static inline public function orUse<D, F>(outcome: Outcome<D, F>, fallback: Lazy<D>):D
+    return or(outcome, fallback);
+        
   /**
    *  Extracts the value if the option is `Success`, uses the fallback value otherwise
    */
-  static public function orUse<D, F>(outcome: Outcome<D, F>, fallback: Lazy<D>):D
+  static public function or<D, F>(outcome: Outcome<D, F>, fallback: Lazy<D>):D
     return
       switch (outcome) {
         case Success(data): data;

--- a/tests/Options.hx
+++ b/tests/Options.hx
@@ -5,11 +5,11 @@ using tink.CoreApi;
 @:asserts
 class Options extends Base {
   public function testSure() {
-    asserts.assert(4 == Some(4).force());
+    asserts.assert(4 == Some(4).sure());
     
     throws(
       asserts,
-      function () None.force(),
+      function () None.sure(),
       Error,
       function (e) return e.message == 'Some value expected but none found'
     );

--- a/tests/Options.hx
+++ b/tests/Options.hx
@@ -24,4 +24,21 @@ class Options extends Base {
     return asserts.done();
   }
   
+  public function or() {
+    var some = Some(1);
+    var none = None;
+        
+    asserts.assert(some.orNull() == 1);
+    asserts.assert(none.orNull() == null);
+        
+    asserts.assert(some.or(5) == 1);
+    asserts.assert(none.or(5) == 5);
+        
+    asserts.assert(some.orTry(Some(2)).match(Some(1)));
+    asserts.assert(none.orTry(Some(2)).match(Some(2)));
+    asserts.assert(none.orTry(None).match(None));
+    
+    return asserts.done();
+  }
+  
 }

--- a/tests/Outcomes.hx
+++ b/tests/Outcomes.hx
@@ -44,4 +44,22 @@ class Outcomes extends Base {
     asserts.assert(compare(Failure(Left(true)), outcomes[1].flatMap(function (x) return Failure(x + 2))));
     return asserts.done();
   }
+  
+  public function or() {
+    var success = Success(1);
+    var failure = Failure(true);
+        
+    asserts.assert(success.orNull() == 1);
+    asserts.assert(failure.orNull() == null);
+        
+    asserts.assert(success.or(5) == 1);
+    asserts.assert(failure.or(5) == 5);
+        
+    asserts.assert(success.orTry(Success(2)).match(Success(1)));
+    asserts.assert(failure.orTry(Success(2)).match(Success(2)));
+    asserts.assert(failure.orTry(Failure(false)).match(Failure(false)));
+    
+    return asserts.done();
+  }
+  
 }


### PR DESCRIPTION
- Moved `OutcomeTools. toOutcome(option)` to `OptionTools`
- Added `OptionTools.orTry`
- Added `OutcomeTools.or` and deprecated `OutcomeTools.orUse`
- Added `OptionTools.sure` and deprecated `OptionTools.force`

The last three changes are mainly to unify the API of the two types. Because I can never remember which function is for which type...