### PR TITLE
Add support for .NET core by adding a named param

### DIFF
--- a/src/tink/core/Progress.hx
+++ b/src/tink/core/Progress.hx
@@ -70,7 +70,7 @@ abstract Progress<T>(ProgressObject<T>) from ProgressObject<T> {
 
 private class SuspendableProgress<T> extends ProgressObject<T> {
 
-  function noop(_, _) return null;
+  function noop(_, _b) return null;
   public function new(wakeup:(fire:ProgressStatus<T>->Void)->CallbackLink, ?status) {
     if (status == null)
       status = InProgress(ProgressValue.ZERO);


### PR DESCRIPTION
the noop function has 2 ignore parameters, this is OK for standard dotnet, but for some undocumented reason in dotnet core this is disallowed, so I changed the second param to _b

dotnet core is the future for csharp, and at the moment I see it as a very stable cross platform higher performance target, with stack traces